### PR TITLE
Bugfix/scenario resource names

### DIFF
--- a/scenarios/ciem/aws/codebuild-administrator-servicerole/main.go
+++ b/scenarios/ciem/aws/codebuild-administrator-servicerole/main.go
@@ -10,7 +10,7 @@ func main() {
 	pulumi.Run(func(ctx *pulumi.Context) error {
 
 		// Create IAM Role for CodeBuild
-		role, err := iam.NewRole(ctx, "codeBuildRole", &iam.RoleArgs{
+		role, err := iam.NewRole(ctx, "CnappgoatCodeBuildRole", &iam.RoleArgs{
 			AssumeRolePolicy: pulumi.String(`{
 				"Version": "2012-10-17",
 				"Statement": [
@@ -24,6 +24,9 @@ func main() {
 				  }
 				]
 			  }`),
+			Tags: pulumi.StringMap{
+				"Cnappgoat": pulumi.String("true"),
+			},
 		})
 		if err != nil {
 			return err
@@ -38,7 +41,7 @@ func main() {
 		}
 
 		// Create AWS CodeBuild project
-		_, err = codebuild.NewProject(ctx, "CNAPPGoatCodeBuildproject", &codebuild.ProjectArgs{
+		codebuildProject, err := codebuild.NewProject(ctx, "CNAPPgoatCodeBuildproject", &codebuild.ProjectArgs{
 			Artifacts: codebuild.ProjectArtifactsArgs{
 				Type: pulumi.String("NO_ARTIFACTS"),
 			},
@@ -58,12 +61,15 @@ phases:
 			},
 			ServiceRole:  role.Arn,
 			BuildTimeout: pulumi.Int(5),
+			Tags: pulumi.StringMap{
+				"Cnappgoat": pulumi.String("true"),
+			},
 		})
 		if err != nil {
 			return err
 		}
-		ctx.Export("roleName", role.Name)
 		ctx.Export("roleArn", role.Arn)
+		ctx.Export("codebuildProject", codebuildProject.Arn)
 		return nil
 	})
 }

--- a/scenarios/cspm/aws/codebuild-build-secrets/main.go
+++ b/scenarios/cspm/aws/codebuild-build-secrets/main.go
@@ -16,7 +16,6 @@ func main() {
 			return err
 		}
 		accountID := callerIdentity.AccountId
-		// Create IAM Role for CodeBuild
 		codebuildRole, err := iam.NewRole(ctx, "codebuildRole", &iam.RoleArgs{
 			AssumeRolePolicy: pulumi.String(`{
 				"Version": "2012-10-17",
@@ -30,6 +29,9 @@ func main() {
 					}
 				]
 			}`),
+			Tags: pulumi.StringMap{
+				"Cnappgoat": pulumi.String("true"),
+			},
 		})
 		if err != nil {
 			return err
@@ -81,13 +83,13 @@ func main() {
 		}`, accountID, accountID, accountID)
 
 		// Create a Role Policy and attach it to the Role
-		_, err = iam.NewRolePolicy(ctx, "codebuildRolePolicy", &iam.RolePolicyArgs{
+		_, err = iam.NewRolePolicy(ctx, "CnappgoatCodebuildRolePolicy", &iam.RolePolicyArgs{
 			Role:   codebuildRole.Name,
 			Policy: pulumi.String(policy),
 		})
 
 		// Create AWS CodeBuild project
-		_, err = codebuild.NewProject(ctx, "cnappgoat-codebuild", &codebuild.ProjectArgs{
+		codebuildProject, err := codebuild.NewProject(ctx, "cnappgoat-codebuild", &codebuild.ProjectArgs{
 			Name: pulumi.String("cnappgoat-codebuild"),
 			Artifacts: codebuild.ProjectArtifactsArgs{
 				Type: pulumi.String("NO_ARTIFACTS"),
@@ -108,11 +110,15 @@ phases:
 			},
 			ServiceRole:  codebuildRole.Arn,
 			BuildTimeout: pulumi.Int(5),
+			Tags: pulumi.StringMap{
+				"Cnappgoat": pulumi.String("true"),
+			},
 		})
 		if err != nil {
 			return err
 		}
-
+		ctx.Export("codebuildRole", codebuildRole.Arn)
+		ctx.Export("codebuildProject", codebuildProject.Arn)
 		return nil
 	})
 }


### PR DESCRIPTION
Fix naming conventions in 2 CSPM and 1 CIEM scenario:
for:
* cspm-aws-codebuild-build-secrets
* ciem-aws-codebuild-administrator-servicerole
* cspm-aws-s3-public-bucket-secrets
I did the following
- tag resources
- change naming to match convention
- export outputs